### PR TITLE
Third Step -Support different delimiters

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -21,12 +21,6 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('StringCalculator-TDD');
   });
 
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, StringCalculator-TDD');
-  });
 
   it('should return 0 for an empty string', () => {
     const fixture = TestBed.createComponent(AppComponent);
@@ -65,5 +59,26 @@ describe('AppComponent', () => {
     const app = fixture.componentInstance;
     expect(app.Add('1\n2,3')).toBe(6);
     expect(app.Add('10\n20,30')).toBe(60);
+  });
+
+  it('should handle custom delimiter', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    expect(app.Add('//;\n1;2')).toBe(3);
+    expect(app.Add('//-\n4-5-6')).toBe(15);
+    expect(app.Add('//#\n10#20#30')).toBe(60);
+  });
+
+  it('should support custom delimiter with multiple numbers', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    expect(app.Add('//;\n1;2;3;4')).toBe(10);
+  });
+
+  it('should still support default delimiters when no custom delimiter is given', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    expect(app.Add('1,2')).toBe(3);
+    expect(app.Add('1\n2,3')).toBe(6);
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -17,11 +17,20 @@ export class AppComponent {
       return 0;
     }
 
-    // Replace newlines with commas and split numbers by comma
-    const numArray = numbers.replace(/\n/g, ',').split(',').map(Number);
+    let delimiter = /,|\n/;  // Default delimiter (comma or newline)
+
+    // Check if there's a custom delimiter
+    if (numbers.startsWith("//")) {
+      const delimiterEnd = numbers.indexOf("\n");
+      delimiter = new RegExp(numbers.substring(2, delimiterEnd));  // Extract the custom delimiter
+      numbers = numbers.substring(delimiterEnd + 1);  // Remove the delimiter declaration line
+    }
+
+    const numArray = numbers.split(delimiter).map(Number);
 
     return numArray.reduce((a, b) => a + b, 0);
   }
 
 
-}
+
+  }


### PR DESCRIPTION
to change a delimiter, the beginning of the string will contain a separate line that looks like this: “//[delimiter]\n[numbers…]” for example “//;\n1;2” should return three where the default delimiter is ‘;’ .
the first line is optional. all existing scenarios should still be supported